### PR TITLE
Don't convert path to unicode

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -39,7 +39,7 @@ export async function activate(context: ExtensionContext) {
 	clientServer.listen(clientPort);
 
 	// start docker container
-	const dockerBinds = workspace.workspaceFolders.map(wsFolder => `${wsFolder.uri.toString().replace('file://', '')}:/profiling/${wsFolder.name}`);
+	const dockerBinds = workspace.workspaceFolders.map(wsFolder => `${wsFolder.uri.toString(true).replace('file://', '')}:/profiling/${wsFolder.name}`);
 	dockerBinds.forEach(a => console.log(a));
 
 	let serverOptions = () => startServerDockerContainer(dockerBinds);


### PR DESCRIPTION
### Summary
* Fixed error where profiler container would not start as I have an `@` in my path. it would be converted into unicode.

### Testing
* Verified that my profiler now works.

Signed-off-by: James Wallis <james.wallis1@ibm.com>