### PR TITLE
Add IBM license

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,8 +1,13 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 import * as path from 'path';
 import * as net from 'net';
 import { workspace, ExtensionContext } from 'vscode';

--- a/client/src/test/completion.test.ts
+++ b/client/src/test/completion.test.ts
@@ -1,8 +1,13 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 import * as vscode from 'vscode';
 import * as assert from 'assert';
 import { getDocUri, activate } from './helper';

--- a/client/src/test/diagnostics.test.ts
+++ b/client/src/test/diagnostics.test.ts
@@ -1,8 +1,13 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 import * as vscode from 'vscode'
 import * as assert from 'assert'
 import { getDocUri, activate } from './helper'

--- a/client/src/test/helper.ts
+++ b/client/src/test/helper.ts
@@ -1,8 +1,13 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 import * as vscode from 'vscode';
 import * as path from 'path';
 

--- a/client/src/test/index.ts
+++ b/client/src/test/index.ts
@@ -1,8 +1,13 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 import * as testRunner from 'vscode/lib/testrunner';
 
 testRunner.configure({

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,13 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 FROM ibmjava:sdk
 RUN cd /opt && \
     wget http://www-eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz && \

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HCDProfiler.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HCDProfiler.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
 import java.io.BufferedWriter;

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
 import java.io.Console;

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/LanguageServerUtils.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/LanguageServerUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
 import org.eclipse.lsp4j.MessageParams;

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingLanguageServer.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingLanguageServer.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
 import java.util.List;

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
 import java.io.File;

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
 import java.util.List;

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/StartServer.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/StartServer.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 import java.io.IOException;
 import java.io.InputStream;

--- a/server/src/test/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtilsTest.java
+++ b/server/src/test/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtilsTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
 import java.io.UnsupportedEncodingException;


### PR DESCRIPTION
### Summary
Added an IBM license header to each file which contains a Microsoft one and also the source and test code for the server directory.

Signed-off-by: James Wallis <james.wallis1@ibm.com>