### PR TITLE
[0.9.0] remove microclimate refs

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,4 +21,4 @@ RUN echo `ls`;
 RUN mvn install:install-file -Dfile=/opt/ibm/java/jre/lib/tools/monitoring-api.jar -DgroupId=com.ibm.java.diagnostics.healthcenter -DartifactId=com.ibm.java.diagnostics.healthcenter -Dversion=1.0 -Dpackaging=jar
 RUN mvn clean install
 WORKDIR /profiling/target
-CMD java -jar MicrocliomateJavaProfilingLanguageServer-0.0.1-SNAPSHOT-jar-with-dependencies.jar
+CMD java -jar CodewindJavaProfilingLanguageServer-0.0.1-SNAPSHOT-jar-with-dependencies.jar

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,4 +21,4 @@ RUN echo `ls`;
 RUN mvn install:install-file -Dfile=/opt/ibm/java/jre/lib/tools/monitoring-api.jar -DgroupId=com.ibm.java.diagnostics.healthcenter -DartifactId=com.ibm.java.diagnostics.healthcenter -Dversion=1.0 -Dpackaging=jar
 RUN mvn clean install
 WORKDIR /profiling/target
-CMD java -jar CodewindJavaProfilingLanguageServer-0.0.1-SNAPSHOT-jar-with-dependencies.jar
+CMD java -jar CodewindJavaProfilingLanguageServer-0.9.0-jar-with-dependencies.jar

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -2,9 +2,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ibm</groupId>
-	<artifactId>MicrocliomateJavaProfilingLanguageServer</artifactId>
+	<artifactId>CodewindJavaProfilingLanguageServer</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>Microcliomate Java Profiling Language Server</name>
+	<name>Codewind Java Profiling Language Server</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ibm</groupId>
 	<artifactId>CodewindJavaProfilingLanguageServer</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.9.0</version>
 	<name>Codewind Java Profiling Language Server</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/server/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/server/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -1,3 +1,0 @@
-/Users/jonathanspruce/Projects/eclipse/lsp4j/MicrocliomateJavaProfilingLanguageServer/src/main/java/com/ibm/JavaProfilingLanguageServer/StartServer.java
-/Users/jonathanspruce/Projects/eclipse/lsp4j/MicrocliomateJavaProfilingLanguageServer/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingLanguageServer.java
-/Users/jonathanspruce/Projects/eclipse/lsp4j/MicrocliomateJavaProfilingLanguageServer/src/main/java/com/ibm/JavaProfilingLanguageServer/HCDProfiler.java


### PR DESCRIPTION
microclimate is still mentioned in various places (due to a typo), replacing all these with codewind.

output after running tests
```[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s - in com.ibm.JavaProfilingLanguageServer.ProfilingUtilsTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.687 s
[INFO] Finished at: 2020-02-18T10:51:44+00:00
[INFO] Final Memory: 11M/21M
[INFO] ------------------------------------------------------------------------
```

Signed-off-by: Toby Corbin <corbint@uk.ibm.com>