### PR TITLE
Fix profiler for windows

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -10,9 +10,10 @@
  *******************************************************************************/
 import * as path from 'path';
 import * as net from 'net';
-import { workspace,
-		 ExtensionContext,
-		 WorkspaceFolder
+import { 
+    workspace,
+    ExtensionContext,
+    WorkspaceFolder
 } from 'vscode';
 import {
 	LanguageClient,
@@ -41,11 +42,11 @@ let serverConnected = false;
 let connectionSocket;
 
 function workspaceFolderToDockerBind(wsFolder: WorkspaceFolder): string {
-	let folderUriString = wsFolder.uri.toString(true);
-	if (onWin) {
-		folderUriString = folderUriString.replace('%3A', '').replace('file://', '');
-	}
-	return `${folderUriString}:/profiling/${wsFolder.name}`;
+    let folderUriString = wsFolder.uri.toString(true);
+    if (onWin) {
+        folderUriString = folderUriString.replace('%3A', '').replace('file://', '');
+    }
+    return `${folderUriString}:/profiling/${wsFolder.name}`;
 }
 
 export async function activate(context: ExtensionContext) {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -42,9 +42,9 @@ let serverConnected = false;
 let connectionSocket;
 
 function workspaceFolderToDockerBind(wsFolder: WorkspaceFolder): string {
-    let folderUriString = wsFolder.uri.toString(true);
+    let folderUriString = wsFolder.uri.toString(true).replace('file://', '');
     if (onWin) {
-        folderUriString = folderUriString.replace('file://', '').replace(':', '');
+        folderUriString = folderUriString.replace(':', '');
     }
     return `${folderUriString}:/profiling/${wsFolder.name}`;
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -21,13 +21,13 @@ import { promisify } from 'util';
 
 import * as tarfs from 'tar-fs';
 import * as Docker from 'dockerode';
-import * as ip from 'ip';
 
 const docker = new Docker();
 
 const followProgress = promisify(docker.modem.followProgress);
 
 const clientPort: number = 3333;
+const clientHost: string = "127.0.0.1"
 const dockerRepo: string = 'ibmcom';
 const dockerImage: string = 'codewind-java-profiler-language-server';
 const dockerTag: string = 'latest';
@@ -36,6 +36,10 @@ let clientServer: net.Server;
 let client: LanguageClient;
 let serverConnected = false;
 let connectionSocket;
+let onWin = false;
+if (process.platform === 'win32') {
+	onWin = true;
+}
 
 export async function activate(context: ExtensionContext) {
 
@@ -158,7 +162,7 @@ async function removeExistingContainer() {
 }
 
 async function startContainer(dockerBinds: string[]) {
-	console.log(`CLIENT_PORT=${clientPort}, CLIENT_HOST=${ip.address()}, BINDS="${dockerBinds}"`);
+	console.log(`CLIENT_PORT=${clientPort}, CLIENT_HOST=${clientHost}, BINDS="${dockerBinds}"`);
 	const container = await docker.createContainer({
 		Image: dockerFullImageName,
 		name: dockerImage,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -30,7 +30,7 @@ const docker = new Docker();
 const followProgress = promisify(docker.modem.followProgress);
 
 const clientPort: number = 3333;
-const clientHost: string = "host.docker.internal"
+const clientHost: string = 'host.docker.internal';
 const dockerRepo: string = 'ibmcom';
 const dockerImage: string = 'codewind-java-profiler-language-server';
 const dockerTag: string = 'latest';

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -91,17 +91,16 @@ async function startServerDockerContainer(dockerBinds: string[]) {
 		// don't care if already removed
 	}
 
-	// try {
-	// 	console.log(`Trying to pull image ${dockerFullImageName}`);
+	try {
+		console.log(`Trying to pull image ${dockerFullImageName}`);
 
-	// 	await pullDockerImage();
-	// 	console.log('Pull completed!');
-	// } catch (error) {
-	// 	console.log('Pull failed, building from local Dockerfile');
-	// 	await buildLocalDockerImage();
-	// 	console.log(error);
-	// }
-	await buildLocalDockerImage();
+		await pullDockerImage();
+		console.log('Pull completed!');
+	} catch (error) {
+		console.log('Pull failed, building from local Dockerfile');
+		await buildLocalDockerImage();
+		console.log(error);
+	}
 	await startContainer(dockerBinds);
 
 	setupConnectionListeners();

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -44,7 +44,7 @@ let connectionSocket;
 function workspaceFolderToDockerBind(wsFolder: WorkspaceFolder): string {
     let folderUriString = wsFolder.uri.toString(true);
     if (onWin) {
-        folderUriString = folderUriString.replace('%3A', '').replace('file://', '');
+        folderUriString = folderUriString.replace('file://', '').replace(':', '');
     }
     return `${folderUriString}:/profiling/${wsFolder.name}`;
 }

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
@@ -12,7 +12,6 @@ package com.ibm.JavaProfilingLanguageServer;
 
 import java.io.Console;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -67,9 +66,8 @@ public class HotMethod {
 
 	public Range findInTextDocument(TextDocumentItem textDocument) {
 		String[] nameInFile = withinFileName.split("\\.");
-		System.out.println("nameInFile = " + Arrays.toString(nameInFile));
 		String textWithoutComments = removeCommentsFromText(textDocument.getText());
-		
+
 		Range contextRange = new Range();
 		contextRange.setStart(new Position(0,0));
 		contextRange.setEnd(new Position(999999, 999999));
@@ -78,29 +76,25 @@ public class HotMethod {
 			for (int i = 0; i < nameInFile.length; i++) {
 				String context = nameInFile[i];
 				contextRange = getRangeInTextWithinScope(context, textWithoutComments, contextRange, i);
-				System.out.println("contextRange = " + contextRange);
 			}
 
 			String[] lines = textDocument.getText().split("\\r?\\n");
-			System.out.println("lines = " + Arrays.toString(lines));
 			int startOfMethodName = contextRange.getStart().getCharacter();
 
 			String findHotMethodString = methodName + "\\(.*\\)";
-			System.out.println("findHotMethodString = " + findHotMethodString);
 			Pattern findPackage = Pattern.compile(findHotMethodString);
 			Matcher m = findPackage.matcher(lines[contextRange.getStart().getLine()]);
 			int endOfMethodName = m.find() ? m.group(0).length() : methodName.length();
 
 			contextRange.setEnd(new Position(contextRange.getStart().getLine(), startOfMethodName + endOfMethodName));
 
-					System.out.println("*** FINAL SCOPE ***");
-					System.out.printf("Range: start: %s:%s, end: %s:%s%n",
-							contextRange.getStart().getLine(), contextRange.getStart().getCharacter(),
-							contextRange.getEnd().getLine(), contextRange.getEnd().getCharacter());
+			// System.out.println("*** FINAL SCOPE ***");
+			// System.out.printf("Range: start: %s:%s, end: %s:%s%n",
+			// 	contextRange.getStart().getLine(), contextRange.getStart().getCharacter(),
+			// 	contextRange.getEnd().getLine(), contextRange.getEnd().getCharacter());
 
 		} catch (Exception e) {
 			System.out.println("Context not found within file");
-			e.printStackTrace();
 		}
 		return contextRange;
 	}
@@ -163,35 +157,29 @@ public class HotMethod {
 	}
 
 	private Range getRangeInTextWithinScope(String scope, String text, Range range, int scopeDepth) {
-		System.out.printf("scope: %s, text: %s, range: %s, scopeDepth: %s\n", scope, text, range, scopeDepth);
+		// System.out.printf("scope: %s, text: %s, range: %s, scopeDepth: %s\n", scope, text, range, scopeDepth);
 		Range scopedRange = new Range();
-		System.out.println("Looking for scope: " + scope);
 		String[] lines = text.split("\\r?\\n");
 		List<String> scopedLines = new ArrayList<String>();
 
 		boolean scopeFound = false;
 		boolean firstBracketFound = false;
 		int stepInto = 0;
-		System.out.println("i starts as " + range.getStart().getLine());
-		System.out.println("i finishes as <= " + range.getEnd().getLine() + " or " + (lines.length - 1));
 
 		for (int i = range.getStart().getLine(); i <= Math.min(range.getEnd().getLine(), lines.length - 1); i++) {
 			String line = lines[i];
 
 			if(!scopeFound && stepInto == scopeDepth) {
 				if(line.contains(scope)) {
-					System.out.println("found " + scope + " in " + line);
 					Position start = new Position();
 					scopeFound = true;
 					start.setLine(i);
 					start.setCharacter(line.indexOf(scope));
-					System.out.println("start = " + start);
 					scopedRange.setStart(start);
 				}
 			}
 
 			if(line.contains("{")) {
-				System.out.println(line + " contains {");
 				if(scopeFound && stepInto == scopeDepth) {
 					System.out.println("first bracket found");
 					firstBracketFound = true;
@@ -206,17 +194,15 @@ public class HotMethod {
 			if(firstBracketFound) {
 				scopedLines.add(line);
 				if(stepInto == scopeDepth) {
-					System.out.println("Setting end");
 					Position end = new Position();
 					end.setLine(i);
 					end.setCharacter(line.length());
-					System.out.println("end = " + end);
 					scopedRange.setEnd(end);
 					break;
 				}
 			}
 
-			System.out.printf("[%s][%s]: %s%n", stepInto, scopeDepth, line);
+			// System.out.printf("[%s][%s]: %s%n", stepInto, scopeDepth, line);
 		}
 		return scopedRange;
 	}

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
 
-import java.io.Console;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -144,17 +143,17 @@ public class HotMethod {
 		return finalString;
 	}
 
-	private int countMatches(String inputString, String stringToMatch) {
-		int count = 0;
-		int fromIndex = 0;
-		int foundIndex = inputString.indexOf(stringToMatch, fromIndex);
-		while (foundIndex != -1) {
-			count++;
-			fromIndex = foundIndex + 1;
-			foundIndex = inputString.indexOf(stringToMatch, fromIndex);
-		}
-		return count;
-	}
+    private int countMatches(String inputString, String stringToMatch) {
+        int count = 0;
+        int fromIndex = 0;
+        int foundIndex = inputString.indexOf(stringToMatch, fromIndex);
+        while (foundIndex != -1) {
+            count++;
+            fromIndex = foundIndex + 1;
+            foundIndex = inputString.indexOf(stringToMatch, fromIndex);
+        }
+        return count;
+    }
 
 	private Range getRangeInTextWithinScope(String scope, String text, Range range, int scopeDepth) {
 		// System.out.printf("scope: %s, text: %s, range: %s, scopeDepth: %s\n", scope, text, range, scopeDepth);
@@ -181,7 +180,6 @@ public class HotMethod {
 
 			if(line.contains("{")) {
 				if(scopeFound && stepInto == scopeDepth) {
-					System.out.println("first bracket found");
 					firstBracketFound = true;
 				}
 				stepInto += countMatches(line, "{");

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/HotMethod.java
@@ -87,11 +87,6 @@ public class HotMethod {
 
 			contextRange.setEnd(new Position(contextRange.getStart().getLine(), startOfMethodName + endOfMethodName));
 
-			// System.out.println("*** FINAL SCOPE ***");
-			// System.out.printf("Range: start: %s:%s, end: %s:%s%n",
-			// 	contextRange.getStart().getLine(), contextRange.getStart().getCharacter(),
-			// 	contextRange.getEnd().getLine(), contextRange.getEnd().getCharacter());
-
 		} catch (Exception e) {
 			System.out.println("Context not found within file");
 		}
@@ -156,7 +151,6 @@ public class HotMethod {
     }
 
 	private Range getRangeInTextWithinScope(String scope, String text, Range range, int scopeDepth) {
-		// System.out.printf("scope: %s, text: %s, range: %s, scopeDepth: %s\n", scope, text, range, scopeDepth);
 		Range scopedRange = new Range();
 		String[] lines = text.split("\\r?\\n");
 		List<String> scopedLines = new ArrayList<String>();

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
@@ -154,7 +154,6 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 		List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
 
 		String documentPackage = getDocumentPackage(textDocument);
-		// System.out.println("documentPackage: " + documentPackage);
 
 		File hcd = getHCDFromLoadTestDir(loadTestResults);
 

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
@@ -154,6 +154,7 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 		List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
 
 		String documentPackage = getDocumentPackage(textDocument);
+		// System.out.println("documentPackage: " + documentPackage);
 
 		File hcd = getHCDFromLoadTestDir(loadTestResults);
 

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingTextDocumentService.java
@@ -67,18 +67,13 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 	}
 
 	private List<String> searchForFolders(File currentDir, String targetDirName) {
-		System.out.println("searchForFolders >> currentDir=" + currentDir.getPath() + ", targetDirName=" + targetDirName);
 		List<String> projectPaths = new ArrayList<String>();
 
 		File currentPath = new File(currentDir.getPath());
-		System.out.println("searchForFolders >> currentPath=" + currentPath.getPath());
 		if(currentPath.isDirectory()) {
-			System.out.println("currentPath is directory");
 			if(currentPath.getName().equals(targetDirName)) {
-				System.out.println("currentPath equals targetPath");
 				projectPaths.add(currentPath.getPath());
 			} else if(!currentPath.getName().startsWith(".") && !currentPath.getPath().contains("node_modules")) {
-				System.out.println("Finding child files");
 				File[] childFiles = currentPath.listFiles();
 				for (File file : childFiles) {
 					projectPaths.addAll(searchForFolders(file, targetDirName));
@@ -91,7 +86,7 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 
 	public void didOpen(DidOpenTextDocumentParams params) {
 		TextDocumentItem document = params.getTextDocument();
-		System.out.printf("didOpen: %s%n%n", document.getUri().replace("%3A", ""));
+		System.out.printf("didOpen: %s%n%n", ProfilingUtils.convertColon(document.getUri()));
 
 		publishProfilingDiagnostics(document);
 	}
@@ -100,11 +95,10 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 
 		// create diagnostics object and link it to current file
 		PublishDiagnosticsParams diagnosticParams = new PublishDiagnosticsParams();
-		System.out.println("TextDocURI = " + textDocument.getUri());
 		diagnosticParams.setUri(textDocument.getUri());
 
 		// convert URI to docker version
-		textDocument.setUri(ProfilingUtils.dockerizeFilePath(textDocument.getUri().replace("%3A", "")));
+		textDocument.setUri(ProfilingUtils.dockerizeFilePath(ProfilingUtils.convertColon(textDocument.getUri())));
 
 		String projectPath = getProjectForPath(textDocument.getUri());
 		System.out.println("Project Path for file: " + projectPath + "\n");
@@ -121,7 +115,6 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 
 		List<Diagnostic> diagnostics = getDiagnosticsForFile(textDocument, loadTestResults);
 		diagnosticParams.setDiagnostics(diagnostics);
-		System.out.println("diagnosticParams = " + diagnosticParams);
 
 		System.out.println("Sending diagnostics");
 		// send diagnostics to the client
@@ -161,7 +154,6 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 		List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
 
 		String documentPackage = getDocumentPackage(textDocument);
-		System.out.println("documentPackage: " + documentPackage);
 
 		File hcd = getHCDFromLoadTestDir(loadTestResults);
 
@@ -177,7 +169,6 @@ public class ProfilingTextDocumentService implements TextDocumentService {
 			Range diagnosticRange = hotMethod.findInTextDocument(textDocument);
 
 			String message = String.format("Method %s() was the running function during load testing %.1f%% of the time.", hotMethod.getMethodName(), hotMethod.getPercentage());
-			System.out.println("message = " + message);
 
 			Diagnostic d = new Diagnostic();
 			d.setSource("Codewind Java Profiler");

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
@@ -39,7 +39,6 @@ public class ProfilingUtils {
 	}
 
 	public static String dockerizeFilePathUsingMountedVolume(String path, String mount) {
-		System.out.println("dFPuMV >> path=" + path + ", mount = " + mount);
 		// try to re-add special characters to the path string
 		String unescapedPath;
 		try {
@@ -47,15 +46,12 @@ public class ProfilingUtils {
 		} catch (UnsupportedEncodingException e) {
 			unescapedPath = path;
 		}
-		System.out.println("dFPuMV >> unescapedPath= " + unescapedPath);
 		// the workspace passed in should be in format /host/path:/docker/path
 		String mounts = mount.replace("\"", "");
 		int lastColonIndex = mounts.lastIndexOf(":");
 		String hostWorkspace = mounts.substring(0, lastColonIndex);
 		String dockerWorkspace = mounts.substring(lastColonIndex+1);
 		String newString = unescapedPath.replace(hostWorkspace, dockerWorkspace);
-		System.out.println("dFPuMV >> hostWorkspace= " + hostWorkspace);
-		System.out.println("dFPuMV >> dockerWorkspace= " + dockerWorkspace);
 
 		System.out.println("dockerizeFilePathUsingMountedVolume: " + newString + "\n");
 
@@ -73,13 +69,13 @@ public class ProfilingUtils {
 		return workspaceFolders;
 	}
 
-	public static String convertColon(String uriString) {
-		if (ON_WIN) {
-			return uriString.replace("%3A", "");
-		} else {
-			return uriString;
-		}
-	}
+    public static String convertColon(String uriString) {
+        if (ON_WIN) {
+            return uriString.replace("%3A", "");
+        } else {
+            return uriString;
+        }
+    }
 
 	/**
 	 * Removes the additional bits added to the start of the file paths, e.g. `file://` to give a file path which can be used

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
@@ -38,6 +38,7 @@ public class ProfilingUtils {
 	}
 
 	public static String dockerizeFilePathUsingMountedVolume(String path, String mount) {
+		System.out.println("dFPuMV >> path=" + path + ", mount = " + mount);
 		// try to re-add special characters to the path string
 		String unescapedPath;
 		try {
@@ -45,12 +46,15 @@ public class ProfilingUtils {
 		} catch (UnsupportedEncodingException e) {
 			unescapedPath = path;
 		}
-
+		System.out.println("dFPuMV >> unescapedPath= " + unescapedPath);
 		// the workspace passed in should be in format /host/path:/docker/path
-		String[] mounts = mount.replace("\"", "").split(":");
-		String hostWorkspace = mounts[0];
-		String dockerWorkspace = mounts[1];
+		String mounts = mount.replace("\"", "");
+		int lastColonIndex = mounts.lastIndexOf(":");
+		String hostWorkspace = mounts.substring(0, lastColonIndex);
+		String dockerWorkspace = mounts.substring(lastColonIndex+1);
 		String newString = unescapedPath.replace(hostWorkspace, dockerWorkspace);
+		System.out.println("dFPuMV >> hostWorkspace= " + hostWorkspace);
+		System.out.println("dFPuMV >> dockerWorkspace= " + dockerWorkspace);
 
 		System.out.println("dockerizeFilePathUsingMountedVolume: " + newString + "\n");
 
@@ -61,7 +65,7 @@ public class ProfilingUtils {
 		// update folder paths for Docker container
 		if(workspaceFolders != null) {
 			for (WorkspaceFolder folder : workspaceFolders) {
-				folder.setUri(ProfilingUtils.dockerizeFilePath(folder.getUri()));
+				folder.setUri(ProfilingUtils.dockerizeFilePath(folder.getUri().replace("%3A", "")));
 			}
 		}
 

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/ProfilingUtils.java
@@ -19,6 +19,7 @@ public class ProfilingUtils {
 
 	public final static String LOAD_TEST_DIRECTORY = "load-test";
 	public static String[] mountedVolumes = {};
+	private final static boolean ON_WIN = Boolean.parseBoolean(System.getenv("WINDOWS_HOST"));
 
 	/**
 	 * Converts the external path to a path recognised within the docker container
@@ -65,11 +66,19 @@ public class ProfilingUtils {
 		// update folder paths for Docker container
 		if(workspaceFolders != null) {
 			for (WorkspaceFolder folder : workspaceFolders) {
-				folder.setUri(ProfilingUtils.dockerizeFilePath(folder.getUri().replace("%3A", "")));
+				folder.setUri(ProfilingUtils.dockerizeFilePath(convertColon(folder.getUri())));
 			}
 		}
 
 		return workspaceFolders;
+	}
+
+	public static String convertColon(String uriString) {
+		if (ON_WIN) {
+			return uriString.replace("%3A", "");
+		} else {
+			return uriString;
+		}
 	}
 
 	/**

--- a/server/src/main/java/com/ibm/JavaProfilingLanguageServer/StartServer.java
+++ b/server/src/main/java/com/ibm/JavaProfilingLanguageServer/StartServer.java
@@ -9,12 +9,14 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.JavaProfilingLanguageServer;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ConnectException;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.launch.LSPLauncher;
@@ -36,7 +38,7 @@ public class StartServer {
 		try {
 			ProfilingUtils.mountedVolumes = BINDS.split(",");
 			System.out.println("BINDS:");
-			System.out.println(ProfilingUtils.mountedVolumes);
+			System.out.println(Arrays.toString(ProfilingUtils.mountedVolumes));
 			System.out.println();
 			Socket socket = new Socket(HOST, PORT);
 			in = socket.getInputStream();


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2229

This PR allows the Java profiler to deal with Windows paths whilst preserving the working Unix path structure. It also contains fixes for the HotMethod scoping to accurately tally brackets to determine where class and method scope ends.

Tested manually in both Windows and Mac environments.

Please squash and merge.