### PR TITLE
mount codewind volume in profiler; correct folder path

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -31,6 +31,7 @@ const followProgress = promisify(docker.modem.followProgress);
 
 const clientPort: number = 3333;
 const clientHost: string = 'host.docker.internal';
+const codewindVolumeName: string = 'codewind_cw-workspace';
 const dockerRepo: string = 'ibmcom';
 const dockerImage: string = 'codewind-java-profiler-language-server';
 const dockerTag: string = 'latest';
@@ -46,7 +47,7 @@ function workspaceFolderToDockerBind(wsFolder: WorkspaceFolder): string {
     if (onWin) {
         folderUriString = folderUriString.replace(':', '');
     }
-    return `${folderUriString}:/profiling/${wsFolder.name}`;
+    return `${folderUriString}:/profiling/workspaces/${wsFolder.name}`;
 }
 
 export async function activate(context: ExtensionContext) {
@@ -170,7 +171,7 @@ async function startContainer(dockerBinds: string[]) {
 		name: dockerImage,
 		Env: [`CLIENT_PORT=${clientPort}`, `CLIENT_HOST=${clientHost}`, `BINDS="${dockerBinds}"`, `WINDOWS_HOST=${onWin}`],
 		HostConfig: {
-			Binds: dockerBinds
+			Binds: [ `${codewindVolumeName}:/profiling/workspaces` ]
 		}
 	});
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -114,8 +114,10 @@ async function startServerDockerContainer(dockerBinds: string[]) {
 		await buildLocalDockerImage();
 		console.log(error);
     }
+    await startContainer(dockerBinds);
+
     setupConnectionListeners();
-	const serverSocket = await waitForServerConnection();
+    const serverSocket = await waitForServerConnection();
 
 	// Connect to language server via socket
 	let result: StreamInfo = {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -32,6 +32,7 @@ const followProgress = promisify(docker.modem.followProgress);
 const clientPort: number = 3333;
 const clientHost: string = 'host.docker.internal';
 const codewindVolumeName: string = 'codewind_cw-workspace';
+const dockerWorkspaceMountDir: string = '/profiling/workspaces';
 const dockerRepo: string = 'ibmcom';
 const dockerImage: string = 'codewind-java-profiler-language-server';
 const dockerTag: string = 'latest';
@@ -47,7 +48,7 @@ function workspaceFolderToDockerBind(wsFolder: WorkspaceFolder): string {
     if (onWin) {
         folderUriString = folderUriString.replace(':', '');
     }
-    return `${folderUriString}:/profiling/workspaces/${wsFolder.name}`;
+    return `${folderUriString}:${dockerWorkspaceMountDir}/${wsFolder.name}`;
 }
 
 export async function activate(context: ExtensionContext) {
@@ -171,7 +172,7 @@ async function startContainer(dockerBinds: string[]) {
 		name: dockerImage,
 		Env: [`CLIENT_PORT=${clientPort}`, `CLIENT_HOST=${clientHost}`, `BINDS="${dockerBinds}"`, `WINDOWS_HOST=${onWin}`],
 		HostConfig: {
-			Binds: [ `${codewindVolumeName}:/profiling/workspaces` ]
+			Binds: [ `${codewindVolumeName}:${dockerWorkspaceMountDir}` ]
 		}
 	});
 


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

Fixes https://github.com/eclipse/codewind/issues/2236

This PR mounts the Codewind Docker Volume in the Java Profiler, to allow access to all projects. Workspace pathnames have been altered accordingly.

Tested manually on Windows - will need testing on Mac before being un-WIP'd.